### PR TITLE
[FIX] 팀스페이스 관련 응답 수정 및 팀스페이스 검색 API 추가 생성

### DIFF
--- a/src/main/java/SSOP/ssop/controller/TeamSp/TeamSpController.java
+++ b/src/main/java/SSOP/ssop/controller/TeamSp/TeamSpController.java
@@ -29,18 +29,19 @@ public class TeamSpController {
 
     // 팀스페이스 생성
     @PostMapping("/create")
-    public ResponseEntity<Map<String, String>> saveTeamSp(@RequestBody TeamSp teamSp, @Login Long userId) {
+    public ResponseEntity<?> saveTeamSp(@RequestBody TeamSp teamSp, @Login Long userId) {
         try {
             if (userId == null) {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                         .body(Map.of("message", "유효한 토큰이 없습니다"));
             }
-            teamSpService.saveTeamSp(teamSp, userId); // 호스트 ID와 함께 저장
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(Map.of("message", "팀스페이스 생성 완료"));
+
+            ResponseEntity<?> inviteCodeResponse = teamSpService.saveTeamSp(teamSp, userId);
+            return inviteCodeResponse;
+
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(Map.of("message", "팀스페이스 생성 실패"));
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("message", "팀스페이스 생성 중 오류 발생"));
         }
     }
 

--- a/src/main/java/SSOP/ssop/controller/TeamSp/TeamSpController.java
+++ b/src/main/java/SSOP/ssop/controller/TeamSp/TeamSpController.java
@@ -1,16 +1,13 @@
 package SSOP.ssop.controller.TeamSp;
 
-import SSOP.ssop.config.UserDetail;
 import SSOP.ssop.domain.TeamSp.TeamSp;
 import SSOP.ssop.dto.TeamSp.EnterTeamSpDto;
+import SSOP.ssop.dto.TeamSp.TeamSpInfoDto;
 import SSOP.ssop.security.annotation.Login;
 import SSOP.ssop.service.TeamSp.TeamSpService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -45,18 +42,34 @@ public class TeamSpController {
         }
     }
 
-    // 팀 스페이스 입장
-    @PostMapping("/enter")
-    public ResponseEntity<Map<String, String>> enterTeamSp(@RequestBody EnterTeamSpDto enterTeamSpDto, @Login Long userId) {
+    // 초대코드로 스페이스 검색
+    @GetMapping("/search")
+    public ResponseEntity<?> searchInviteCode(@RequestParam int inviteCode, @Login Long userId) {
         try {
             if (userId == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of("message", "유효한 토큰이 없습니다"));
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body(Map.of("message", "유효한 토큰이 없습니다."));
             }
-            teamSpService.EnterTeamSp(enterTeamSpDto.getInviteCode(), userId);
-            return ResponseEntity.ok(Map.of("message", "팀스페이스에 성공적으로 입장하였습니다."));
+            TeamSpInfoDto teamSpInfoDto = teamSpService.SearchInviteCode(inviteCode, userId);
+            return ResponseEntity.ok(teamSpInfoDto); // 응답 반환
         } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("message",e.getMessage()));
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("message", e.getMessage()));
+        }
+    }
+    // 팀 스페이스 입장
+    @PostMapping("/enter")
+    public ResponseEntity<?> enterTeamSp(@RequestBody EnterTeamSpDto enterTeamSpDto, @Login Long userId) {
+        try {
+            if (userId == null) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body(Map.of("message", "유효한 토큰이 없습니다."));
+            }
+            TeamSpInfoDto teamSpInfoDto = teamSpService.EnterTeamSp(enterTeamSpDto.getInviteCode(), userId);
+            return ResponseEntity.ok(teamSpInfoDto); // 응답 반환
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("message", e.getMessage()));
         }
     }
 

--- a/src/main/java/SSOP/ssop/controller/TeamSp/TeamSpMemberController.java
+++ b/src/main/java/SSOP/ssop/controller/TeamSp/TeamSpMemberController.java
@@ -21,12 +21,12 @@ import java.util.Optional;
 public class TeamSpMemberController {
 
     private final TeamSpMemberService teamSpMemberService;
-    private final SearchService searchService;
+//    private final SearchService searchService;
 
     @Autowired
     public TeamSpMemberController(TeamSpMemberService teamSpMemberService, SearchService searchService) {
         this.teamSpMemberService = teamSpMemberService;
-        this.searchService = searchService;
+//        this.searchService = searchService;
     }
 
     // 기존 카드 제출

--- a/src/main/java/SSOP/ssop/controller/TeamSp/TeamSpMemberController.java
+++ b/src/main/java/SSOP/ssop/controller/TeamSp/TeamSpMemberController.java
@@ -1,10 +1,8 @@
 package SSOP.ssop.controller.TeamSp;
 
-import SSOP.ssop.dto.TeamSp.TeamSpByUserDto;
 import SSOP.ssop.dto.TeamSp.TeamSpMemSortedDto;
 import SSOP.ssop.dto.card.request.SubmitCardRequest;
 import SSOP.ssop.security.annotation.Login;
-import SSOP.ssop.service.SearchService;
 import SSOP.ssop.service.TeamSp.TeamSpMemberService;
 import SSOP.ssop.dto.TeamSp.TeamSpMemberDto;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/SSOP/ssop/controller/TeamSp/TeamSpMemberController.java
+++ b/src/main/java/SSOP/ssop/controller/TeamSp/TeamSpMemberController.java
@@ -21,12 +21,10 @@ import java.util.Optional;
 public class TeamSpMemberController {
 
     private final TeamSpMemberService teamSpMemberService;
-//    private final SearchService searchService;
 
     @Autowired
-    public TeamSpMemberController(TeamSpMemberService teamSpMemberService, SearchService searchService) {
+    public TeamSpMemberController(TeamSpMemberService teamSpMemberService) {
         this.teamSpMemberService = teamSpMemberService;
-//        this.searchService = searchService;
     }
 
     // 기존 카드 제출

--- a/src/main/java/SSOP/ssop/domain/TeamSp/TeamSp.java
+++ b/src/main/java/SSOP/ssop/domain/TeamSp/TeamSp.java
@@ -1,6 +1,7 @@
 package SSOP.ssop.domain.TeamSp;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,6 +15,7 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class TeamSp {
 
     @Id

--- a/src/main/java/SSOP/ssop/domain/TeamSp/TeamSp.java
+++ b/src/main/java/SSOP/ssop/domain/TeamSp/TeamSp.java
@@ -81,7 +81,7 @@ public class TeamSp {
     private boolean showAddress;   // 거주지
 
     @ElementCollection
-    @CollectionTable(name = "plus", joinColumns = @JoinColumn(name = "team_id"))
+    @CollectionTable(name = "plus", joinColumns = @JoinColumn(name = "teamId"))
     @Column(name = "plus")
     private List<String> plus;    // 자유 선택지
 

--- a/src/main/java/SSOP/ssop/domain/TeamSp/TeamSp.java
+++ b/src/main/java/SSOP/ssop/domain/TeamSp/TeamSp.java
@@ -38,6 +38,27 @@ public class TeamSp {
     @Column(name = "inviteCode")
     private int inviteCode;
 
+    @Column(name = "showAge")
+    private boolean showAge;      // 나이
+
+    @Column(name = "showBirth")
+    private boolean showBirth;    // 생년월일
+
+    @Column(name = "showMBTI")
+    private boolean showMBTI;     // mbti
+
+    @Column(name = "showTel")
+    private boolean showTel;      // 연락처
+
+    @Column(name = "showEmail")
+    private boolean showEmail;    // 이메일
+
+    @Column(name = "showInsta")
+    private boolean showInsta;    // 인스타
+
+    @Column(name = "showX")
+    private boolean showX;        // x(트위터)
+
     @Embedded
     private StudentOptional studentOptional;
 
@@ -47,13 +68,25 @@ public class TeamSp {
     @Embedded
     private FanOptional fanOptional;
 
-    @ElementCollection
-    @CollectionTable(name = "student_plus", joinColumns = @JoinColumn(name = "teamId"))
-    @Column(name = "student_plus")
-    private List<String> plus;
+    @Column(name = "showHobby")
+    private boolean showHobby;        // 취미
 
-    @Column(name = "student_card_cover")
-    private String cardCover;
+    @Column(name = "showMusic")
+    private boolean showMusic;       // 인생음악
+
+    @Column(name = "showMovie")
+    private boolean showMovie;      // 인생영화
+
+    @Column(name = "showAddress")
+    private boolean showAddress;   // 거주지
+
+    @ElementCollection
+    @CollectionTable(name = "plus", joinColumns = @JoinColumn(name = "team_id"))
+    @Column(name = "plus")
+    private List<String> plus;    // 자유 선택지
+
+    @Column(name = "showCover")
+    private String cover;         // 카드 커버 (자유/아바타/사진)
 
     @OneToMany(mappedBy = "teamSp", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonIgnore

--- a/src/main/java/SSOP/ssop/dto/TeamSp/TeamSpInfoDto.java
+++ b/src/main/java/SSOP/ssop/dto/TeamSp/TeamSpInfoDto.java
@@ -1,0 +1,24 @@
+package SSOP.ssop.dto.TeamSp;
+
+import SSOP.ssop.domain.TeamSp.TeamSp;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TeamSpInfoDto {
+    private Long teamId;
+    private String team_name;
+    private String team_comment;
+    private Boolean isTemplate;
+    private String template;
+
+    public TeamSpInfoDto(TeamSp teamSp) {
+        this.teamId = teamSp.getTeamId();
+        this.team_name = teamSp.getTeam_name();
+        this.team_comment = teamSp.getTeam_comment();
+        this.isTemplate = teamSp.getIsTemplate();
+        this.template = teamSp.getTemplate();
+    }
+}

--- a/src/main/java/SSOP/ssop/service/KakaoService.java
+++ b/src/main/java/SSOP/ssop/service/KakaoService.java
@@ -7,6 +7,7 @@ import SSOP.ssop.repository.UserRepository;
 import SSOP.ssop.utils.DateUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import java.time.format.DateTimeFormatter;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -35,7 +36,10 @@ public class KakaoService {
         String birthday = kakaoUser.getBirthday();
         LocalDate userBirth = DateUtils.parseBirthdate(birthyear, birthday);
 
-        user.setUser_birth(userBirth);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String userBirthString = userBirth.format(formatter);
+
+        user.setUser_birth(userBirthString);
 
         Optional<User> existingUser = userRepository.findByEmail(user.getEmail());
 

--- a/src/main/java/SSOP/ssop/service/TeamSp/TeamSpMemberService.java
+++ b/src/main/java/SSOP/ssop/service/TeamSp/TeamSpMemberService.java
@@ -22,20 +22,19 @@ import java.util.stream.Collectors;
 public class TeamSpMemberService {
 
     @Autowired
-    private static TeamSpRepository teamSpRepository;
+    private TeamSpRepository teamSpRepository;
 
     @Autowired
-    private static TeamSpMemberRepository teamSpMemberRepository;
+    private TeamSpMemberRepository teamSpMemberRepository;
 
     @Autowired
-    private static MemberRepository memberRepository;
+    private MemberRepository memberRepository;
 
     @Autowired
     private CardRepository cardRepository;
 
     @Autowired
     private CardService cardService;
-    private FilterService filterService;
 
     // 기존 카드 제출
     public void SubmitCard(Long teamId, Long cardId, Long userId) {

--- a/src/main/java/SSOP/ssop/service/TeamSp/TeamSpService.java
+++ b/src/main/java/SSOP/ssop/service/TeamSp/TeamSpService.java
@@ -4,7 +4,7 @@ import SSOP.ssop.domain.TeamSp.Member;
 import SSOP.ssop.domain.TeamSp.TeamSp;
 import SSOP.ssop.domain.TeamSp.TeamSpMember;
 import SSOP.ssop.domain.User;
-import SSOP.ssop.dto.User.UserDto;
+import SSOP.ssop.dto.TeamSp.TeamSpInfoDto;
 import SSOP.ssop.repository.TeamSp.MemberRepository;
 import SSOP.ssop.repository.TeamSp.TeamSpMemberRepository;
 import SSOP.ssop.repository.TeamSp.TeamSpRepository;
@@ -62,8 +62,16 @@ public class TeamSpService {
         return inviteCode;
     }
 
+    // 초대코드 검색
+    public TeamSpInfoDto SearchInviteCode(int inviteCode, Long userId) {
+        TeamSp teamSp = teamSpRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 초대 코드입니다."));
+
+        return new TeamSpInfoDto(teamSp);
+    }
+
     // 팀스페이스 입장
-    public void EnterTeamSp(int inviteCode, Long userId) {
+    public TeamSpInfoDto EnterTeamSp(int inviteCode, Long userId) {
         // 1. 팀스페이스 정보 가져오기
         TeamSp teamSp = teamSpRepository.findByInviteCode(inviteCode)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 초대 코드입니다."));
@@ -83,6 +91,9 @@ public class TeamSpService {
 
         // 5. 팀스페이스 멤버 저장
         teamSpMemberRepository.saveAll(user.getTeamSpMembers());
+
+        // 6. TeamSpInfoDto 결과 반환
+        return new TeamSpInfoDto(teamSp);
     }
 
     // 모든 팀스페이스 Entity 조회

--- a/src/main/java/SSOP/ssop/service/TeamSp/TeamSpService.java
+++ b/src/main/java/SSOP/ssop/service/TeamSp/TeamSpService.java
@@ -4,15 +4,19 @@ import SSOP.ssop.domain.TeamSp.Member;
 import SSOP.ssop.domain.TeamSp.TeamSp;
 import SSOP.ssop.domain.TeamSp.TeamSpMember;
 import SSOP.ssop.domain.User;
+import SSOP.ssop.dto.User.UserDto;
 import SSOP.ssop.repository.TeamSp.MemberRepository;
 import SSOP.ssop.repository.TeamSp.TeamSpMemberRepository;
 import SSOP.ssop.repository.TeamSp.TeamSpRepository;
 import SSOP.ssop.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 
@@ -35,13 +39,16 @@ public class TeamSpService {
     private MemberService memberService;
 
     // 팀스페이스 생성
-    public void saveTeamSp(TeamSp teamSp, Long hostId) {
+    public ResponseEntity<?> saveTeamSp(TeamSp teamSp, Long hostId) {
         teamSp.setHostId(hostId); // 호스트 ID 저장
         teamSp.setInviteCode(createInviteCode()); // 초대코드 자동 생성
-        teamSpRepository.save(teamSp);
+        TeamSp savedTeamSp = teamSpRepository.save(teamSp);
 
-        // 2. 팀스페이스 생성 후 호스트를 자동으로 팀스페이스에 입장시킴
-        EnterTeamSp(teamSp.getInviteCode(), hostId);
+        // 팀스페이스 생성 후 호스트를 자동으로 팀스페이스에 입장시킴
+        EnterTeamSp(savedTeamSp.getInviteCode(), hostId);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(Map.of("inviteCode", savedTeamSp.getInviteCode()));
     }
 
     // 랜덤 코드 생성

--- a/src/main/resources/application-secret.properties
+++ b/src/main/resources/application-secret.properties
@@ -1,4 +1,0 @@
-# ??? ??? ??
-kakao.client.id=9614fdcb14b3ad5c1caab8d704607d6d
-kakao.client.secret=fGHesmLm9RdprrVS5e8Scjh1NgtOOxwf
-kakao.redirect.url=http://localhost:8080/login/kakao


### PR DESCRIPTION
## 연결 Issue
#44 
### 💡 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📲 반영 브랜치
fix/#44-responseTeamSp -> develop

### ❔ 변경 사항
- 팀스페이스 생성
    - 팀스페이스 생성 시, 응답에  초대코드 반환
    - 팀스페이스 생성 변수 추가 ( 취미, 거주지 등)

- 팀스페이스 입장
    - 팀스페이스 검색 by 초대코드 API 추가 생성
    - 팀스페이스 검색/입장 API 요청 시, 참여할(한) 팀스페이스 정보 반환
        - 검색 후 팀스페이스 확인 → team_name/team_comment 보여주기
        - 입장 시, isTemplate 값에 따라 이동할 페이지 조정
        
### 🔍 테스트 결과

### 📰 참고 자료

### ⚒️ 기타 사항