### PR TITLE
[FIX] 내카드 아바타 수정

### DIFF
--- a/src/main/java/SSOP/ssop/domain/card/Avatar.java
+++ b/src/main/java/SSOP/ssop/domain/card/Avatar.java
@@ -32,4 +32,20 @@ public class Avatar {
     @MapsId  // Avatar의 card_id는 Card의 PK와 동일
     @JoinColumn(name = "card_id")
     private Card card;
+
+    // 아바타 값 초기화
+    public void resetAvatar() {
+        this.eyes = 0;
+        this.eyebrows = 0;
+        this.mouth = 0;
+        this.mole = 0;
+        this.hairFront = 0;
+        this.hairBack = 0;
+        this.hairFrontColor = 0;
+        this.hairBackColor = 0;
+        this.clothes = 0;
+        this.acc = 0;
+        this.bg = 0;
+        this.bgColor = 0;
+    }
 }

--- a/src/main/java/SSOP/ssop/domain/card/Card.java
+++ b/src/main/java/SSOP/ssop/domain/card/Card.java
@@ -126,4 +126,5 @@ public class Card {
         this.card_hobby = card_hobby;
         this.card_address = card_address;
     }
+
 }

--- a/src/main/java/SSOP/ssop/service/CardService.java
+++ b/src/main/java/SSOP/ssop/service/CardService.java
@@ -312,12 +312,51 @@ public class CardService {
             cardUtils.updateFieldIfNotNull(profileImageUrl, card::setProfile_image_url);
         }
 
+        if (request.getAvatar() != null) {
+            Avatar avatar = request.getAvatar();
+
+            if (card.getAvatar() != null) {
+                card.getAvatar().resetAvatar();
+                card.getAvatar().setEyes(avatar.getEyes());
+                card.getAvatar().setEyebrows(avatar.getEyebrows());
+                card.getAvatar().setMouth(avatar.getMouth());
+                card.getAvatar().setMole(avatar.getMole());
+                card.getAvatar().setHairFront(avatar.getHairFront());
+                card.getAvatar().setHairBack(avatar.getHairBack());
+                card.getAvatar().setHairFrontColor(avatar.getHairFrontColor());
+                card.getAvatar().setHairBackColor(avatar.getHairBackColor());
+                card.getAvatar().setClothes(avatar.getClothes());
+                card.getAvatar().setAcc(avatar.getAcc());
+                card.getAvatar().setBg(avatar.getBg());
+                card.getAvatar().setBgColor(avatar.getBgColor());
+            } else {
+                Avatar newAvatar = new Avatar();
+                newAvatar.setEyes(avatar.getEyes());
+                newAvatar.setEyebrows(avatar.getEyebrows());
+                newAvatar.setMouth(avatar.getMouth());
+                newAvatar.setMole(avatar.getMole());
+                newAvatar.setHairFront(avatar.getHairFront());
+                newAvatar.setHairBack(avatar.getHairBack());
+                newAvatar.setHairFrontColor(avatar.getHairFrontColor());
+                newAvatar.setHairBackColor(avatar.getHairBackColor());
+                newAvatar.setClothes(avatar.getClothes());
+                newAvatar.setAcc(avatar.getAcc());
+                newAvatar.setBg(avatar.getBg());
+                newAvatar.setBgColor(avatar.getBgColor());
+
+                newAvatar.setCard(card);
+
+                card.setAvatar(newAvatar);
+            }
+        }
+
+
         // 공통 필드 업데이트
         cardUtils.updateFieldIfNotNull(request.getCard_name(), card::setCard_name);
         cardUtils.updateFieldIfNotNull(request.getCard_introduction(), card::setCard_introduction);
         cardUtils.updateFieldIfNotNull(request.getCard_template(), card::setCard_template);
         cardUtils.updateFieldIfNotNull(request.getCard_cover(), card::setCard_cover);
-        cardUtils.updateFieldIfNotNull(request.getAvatar(), card::setAvatar);
+        //cardUtils.updateFieldIfNotNull(request.getAvatar(), card::setAvatar);
         cardUtils.updateFieldIfNotNull(request.getCard_birth(), card::setCard_birth);
         cardUtils.updateFieldIfNotNull(request.getCard_bSecret(), card::setCard_bSecret);
         cardUtils.updateFieldIfNotNull(request.getCard_tel(), card::setCard_tel);


### PR DESCRIPTION
## 연결 Issue
#78 

### 💡 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📲 반영 브랜치
fix/#78-editCard -> develop

### ❔ 변경 사항
커버를 사진에서 아바타로 수정 시, 아바타 기본값 0으로 설정
-> 이 경우에 커버도 아바타라고 함께 보내줘야함 
아바타도 수정할 항목만 보내줘도 반영됨. 단, 처음 아바타 생성하는데 'eyes'만 1로 보내면 나머진 0으로 되어있음.

나머지 수정도 작동되는거 확인 완료
